### PR TITLE
Update reusable publish workflow reference to use the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
                 path: src/Blake.CLI/Blake.CLI.csproj
     steps:
       - name: Publish
-        uses: ./.github/workflows/reusable-publish.yml
+        uses: ./.github/workflows/reusable-publish.yml@main
         with:
           project_path: ${{ matrix.project.path }}
           version: ${{ needs.generate-version.outputs.new_version }}


### PR DESCRIPTION
## Summary

<!-- Describe the change -->
`@main` missing from call to reusable workflow causes it o fail

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
