### PR TITLE
Fix CI and publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,23 +70,20 @@ jobs:
       new_version: ${{ steps.tag_bump.outputs.new_tag }}
 
   publish:
-    needs: generate-version
-    runs-on: ubuntu-latest
-    strategy:
-          matrix:
-            project:
-              - name: Blake.Types
-                path: src/Blake.Types/Blake.Types.csproj
-              - name: Blake.MarkdownParser
-                path: src/Blake.MarkdownParser/Blake.MarkdownParser.csproj
-              - name: Blake.BuildTools
-                path: src/Blake.BuildTools/Blake.BuildTools.csproj
-              - name: Blake.CLI
-                path: src/Blake.CLI/Blake.CLI.csproj
-    steps:
-      - name: Publish
-        uses: ./.github/workflows/reusable-publish.yml@main
-        with:
-          project_path: ${{ matrix.project.path }}
-          version: ${{ needs.generate-version.outputs.new_version }}
-          nuget_key:  ${{ secrets.NUGET_API_KEY }}
+     uses: ./.github/workflows/reusable-publish.yml
+     with:
+      project_path: ${{ matrix.project.path }}
+      version: ${{ needs.generate-version.outputs.new_version }}
+     secrets: inherit
+     needs: generate-version
+     strategy:
+      matrix:
+        project:
+          - name: Blake.Types
+            path: src/Blake.Types/Blake.Types.csproj
+          - name: Blake.MarkdownParser
+            path: src/Blake.MarkdownParser/Blake.MarkdownParser.csproj
+          - name: Blake.BuildTools
+            path: src/Blake.BuildTools/Blake.BuildTools.csproj
+          - name: Blake.CLI
+            path: src/Blake.CLI/Blake.CLI.csproj

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -11,29 +11,23 @@ on:
           description: 'Version to use for packaging'
           type: string
           required: true
-      nuget_key:
-          description: 'NuGet API key'
-          type: string
-          required: true
 
 jobs:
     package-and-publish-lib:
-        runs-on: ubuntu-latest
+      runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v4
+      steps:
+        - uses: actions/checkout@v4
 
-            - name: Setup .NET
-              uses: actions/setup-dotnet@v4
-              with:
-                dotnet-version: 9.0.x
-
-            - name: Generate NuGet package
-              run: |
-                dotnet pack ${{ inputs.project_path }} \
-                --configuration Release \
-                -p:PackageVersion=${{ inputs.version }} \
-                -o packages
-
-            - name: Publish NuGet package
-              run: dotnet nuget push packages/*.nupkg --api-key ${{ inputs.nuget_key }} --source https://api.nuget.org/v3/index.json
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v4
+          with:
+           dotnet-version: 9.0.x
+        - name: Generate NuGet package
+          run: |
+            dotnet pack ${{ inputs.project_path }} \
+            --configuration Release \
+            -p:PackageVersion=${{ inputs.version }} \
+            -o packages
+        - name: Publish NuGet package
+          run: dotnet nuget push packages/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION

## Summary

<!-- Describe the change -->
Fixes a couple of problems with the workflow:
 - Changes the reusable workflow to be defined in the job, not the step
 - Inherit secrets rather than passing them

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
