### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       wait_for_package_id: Blake.Types
       wait_for_package_version: ${{ needs.generate-version.outputs.new_version }}
     secrets: inherit
-    needs: publish-types
+    needs: [publish-types, generate-version]
 
   publish-buildtools:
     uses: ./.github/workflows/reusable-publish.yml
@@ -95,7 +95,7 @@ jobs:
       wait_for_package_id: Blake.MarkdownParser
       wait_for_package_version: ${{ needs.generate-version.outputs.new_version }}
     secrets: inherit
-    needs: publish-markdownparser
+    needs: [publish-markdownparser, generate-version]
 
   publish-cli:
     uses: ./.github/workflows/reusable-publish.yml
@@ -105,4 +105,4 @@ jobs:
       wait_for_package_id: Blake.BuildTools
       wait_for_package_version: ${{ needs.generate-version.outputs.new_version }}
     secrets: inherit
-    needs: publish-buildtools
+    needs: [publish-buildtools, generate-version]

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for ${{ inputs.wait_for_package_id }} to be available on NuGet
+      - name: Wait for ${{ inputs.wait_for_package_id }} version ${{ inputs.wait_for_package_version }} to be available on NuGet
         if: ${{ inputs.wait_for_package_id && inputs.wait_for_package_version }}
         run: |
             PACKAGE_ID_LOWER=$(echo "${{ inputs.wait_for_package_id }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build
         run: |
-          dotnet build ${{ inputs.project_path }} --configuration Release --no-restore --verbosity minimal
+          dotnet build ${{ inputs.project_path }} --configuration Release
 
       - name: Pack
         run: |


### PR DESCRIPTION
## Summary

<!-- Describe the change -->
Previous workflow did not pass version number to subsequent steps

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
