### PR TITLE
Update project file builder to ignore cascading templates

### DIFF
--- a/src/Blake.BuildTools/Generator/ProjectFileBuilder.cs
+++ b/src/Blake.BuildTools/Generator/ProjectFileBuilder.cs
@@ -60,6 +60,9 @@ public static class ProjectFileBuilder
     <Content Remove=""**/template.razor"" />
     <Compile Remove=""**/template.razor"" />
     <None Include=""**/template.razor"" />
+    <Content Remove=""**/cascading-template.razor"" />
+    <Compile Remove=""**/cascading-template.razor"" />
+    <None Include=""**/cascading-template.razor"" />
   </ItemGroup>";
 
         projectContent = projectContent.Insert(projectEndIndex, $"{Environment.NewLine}{blakeContentFolders}{Environment.NewLine}");


### PR DESCRIPTION
## Summary

<!-- Describe the change -->
Updated ProjectFileBuilder.cs to exclude references for cascading-template.razor files in the project content.

Recently #2 added support for cascading templates. However the project file builder was not updated to instruct the compiler to ignore them. This PR corrects that.
---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
