### PR TITLE
Add missing logger parameter in SiteGenerator for LoadPlugins

### DIFF
--- a/src/Blake.BuildTools/Generator/SiteGenerator.cs
+++ b/src/Blake.BuildTools/Generator/SiteGenerator.cs
@@ -38,7 +38,7 @@ internal static class SiteGenerator
         var config = GetConfiguration(options.Arguments);
 
         // Load plugins
-        var plugins = PluginLoader.LoadPlugins(options.ProjectPath, config);
+        var plugins = PluginLoader.LoadPlugins(options.ProjectPath, config, logger);
 
         // Run BeforeBakeAsync for each plugin
         if (plugins.Count > 0)


### PR DESCRIPTION
## Summary

Fixes error introduced by #16 

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
