### PR TITLE
Update command line option for cleaning generated content to use shorthand '-cl'

### DIFF
--- a/src/Blake.CLI/Program.cs
+++ b/src/Blake.CLI/Program.cs
@@ -55,7 +55,7 @@ class Program
         Console.WriteLine("                       Options:");
         Console.WriteLine("                         --disableDefaultRenderers, -dr   Disable the built-in Bootstrap container renderers");
         Console.WriteLine("                         --includeDrafts                  Bakes markdown files that contain 'draft: true' in the frontmatter (they are skipped by default)");
-        Console.WriteLine("                         --clean, -c                      Deletes the .generated folder before re-generating site content");
+        Console.WriteLine("                         --clean, -cl                     Deletes the .generated folder before re-generating site content");
         Console.WriteLine();
         Console.WriteLine("  new <PATH>           Generates a new Blake site");
         Console.WriteLine("                       Options:");
@@ -144,7 +144,7 @@ class Program
             OutputPath          = Path.Combine(targetPath, ".generated"),
             UseDefaultRenderers = !args.Contains("--disableDefaultRenderers") && !args.Contains("-dr"),
             IncludeDrafts       = args.Contains("--includeDrafts"),
-            Clean               = args.Contains("--clean") || args.Contains("-c"),
+            Clean               = args.Contains("--clean") || args.Contains("-cl"),
             Arguments           = [.. args.Skip(1)]
         };
 


### PR DESCRIPTION
## Summary

Fixes #19

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
