### PR TITLE
Fix plugin loading dependencies

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,26 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Build
+        run: |
+          dotnet build
+
+      - name: Test
+        run: |
+          dotnet test

--- a/tests/Blake.IntegrationTests/Commands/BlakePluginTests.cs
+++ b/tests/Blake.IntegrationTests/Commands/BlakePluginTests.cs
@@ -359,7 +359,7 @@ public class BlakePluginTests : TestFixtureBase
         var csprojPath = Path.Combine(testDir, $"{projectName}.csproj");
         var csprojContent = File.ReadAllText(csprojPath);
         
-        var pluginProjectPath = Path.Combine(GetCurrentDirectory(), "tests", "Blake.IntegrationTests", "TestPlugin", "BlakePlugin.TestPlugin.csproj");
+        var pluginProjectPath = Path.Combine(GetCurrentDirectory(), "tests", "Blake.IntegrationTests", "TestPluginWithDependencies", "BlakePlugin.TestPluginWithDependencies.csproj");
         var relativePath = Path.GetRelativePath(testDir, pluginProjectPath);
         
         var updatedCsproj = csprojContent.Replace("</Project>", 
@@ -375,11 +375,12 @@ public class BlakePluginTests : TestFixtureBase
 
         // Assert
         Assert.Equal(0, result.ExitCode);
-        
+
         // Should discover and load plugins
-        Assert.True(
-            result.OutputText.Contains("plugin") ||
-            result.OutputText.Contains("TestPlugin:")
+        Assert.Contains(
+            result.OutputText, o => o.Contains("Plugin with dependencies loaded successfully. Created 100x100 image"));
+        Assert.Contains(
+            result.OutputText, o => o.Contains("Plugin dependencies working in AfterBakeAsync. Created 50x50 image")
         );
     }
 

--- a/tests/Blake.IntegrationTests/Commands/BlakePluginTests.cs
+++ b/tests/Blake.IntegrationTests/Commands/BlakePluginTests.cs
@@ -31,7 +31,7 @@ public class BlakePluginTests : TestFixtureBase
 
         // Assert
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("Build completed successfully", result.OutputText);
+        Assert.Contains(result.OutputText, o => o.Contains("Build completed successfully"));
     }
 
     [Fact]
@@ -134,10 +134,12 @@ public class BlakePluginTests : TestFixtureBase
 
         // Assert
         Assert.Equal(0, result.ExitCode);
-        
+
         // Multiple plugin instances should run (TestPlugin and ContentModifyingPlugin from same assembly)
-        Assert.Contains("TestPlugin: BeforeBakeAsync called", result.OutputText);
-        Assert.Contains("ContentModifyingPlugin: Adding test metadata", result.OutputText);
+        Assert.Contains(result.OutputText, o =>
+            o.Contains("TestPlugin: BeforeBakeAsync called"));
+        Assert.Contains(result.OutputText, o =>
+            o.Contains("ContentModifyingPlugin: Adding test metadata"));
     }
 
     [Fact]
@@ -171,10 +173,11 @@ public class BlakePluginTests : TestFixtureBase
         // Should either handle the error gracefully or continue without the plugin
         if (result.ExitCode != 0)
         {
-            Assert.True(
-                result.ErrorText.Contains("plugin") ||
-                result.ErrorText.Contains("project") ||
-                result.ErrorText.Contains("reference")
+            Assert.Contains(
+                result.ErrorText, o => 
+                    o.Contains("plugin") ||
+                    o.Contains("project") ||
+                    o.Contains("reference")
             );
         }
     }
@@ -231,10 +234,12 @@ public class BlakePluginTests : TestFixtureBase
 
         // Assert
         Assert.Equal(0, result.ExitCode);
-        
+
         // Plugin should have logged correct counts
-        Assert.Contains("BeforeBakeAsync called with 2 markdown pages", result.OutputText);
-        Assert.Contains("AfterBakeAsync called with 2 generated pages", result.OutputText);
+        Assert.Contains(result.OutputText, o =>
+            o.Contains("BeforeBakeAsync called with 2 markdown pages"));
+        Assert.Contains(result.OutputText, o =>
+            o.Contains("AfterBakeAsync called with 2 generated pages"));
     }
 
     [Fact]
@@ -282,7 +287,7 @@ public class BlakePluginTests : TestFixtureBase
 
         // Assert
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("ContentModifyingPlugin: Adding test metadata", result.OutputText);
+        Assert.Contains(result.OutputText, o => o.Contains("ContentModifyingPlugin: Adding test metadata"));
     }
 
     [Fact]
@@ -332,9 +337,9 @@ public class BlakePluginTests : TestFixtureBase
         Assert.Equal(0, result.ExitCode);
         
         // Plugin log messages should appear in output
-        Assert.Contains("TestPlugin: BeforeBakeAsync called", result.OutputText);
-        Assert.Contains("TestPlugin: AfterBakeAsync called", result.OutputText);
-        Assert.Contains("ContentModifyingPlugin:", result.OutputText);
+        Assert.Contains(result.OutputText, o => o.Contains("TestPlugin: BeforeBakeAsync called"));
+        Assert.Contains(result.OutputText, o => o.Contains("TestPlugin: AfterBakeAsync called"));
+        Assert.Contains(result.OutputText, o => o.Contains("ContentModifyingPlugin:"));
     }
 
     [Fact]
@@ -402,7 +407,7 @@ public class BlakePluginTests : TestFixtureBase
 
         // Assert
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("Build completed successfully", result.OutputText);
+        Assert.Contains(result.OutputText, o => o.Contains("Build completed successfully"));
         
         // Should not show plugin-related errors when no project file exists
         Assert.DoesNotContain("plugin", result.ErrorText);
@@ -468,8 +473,8 @@ public class BlakePluginTests : TestFixtureBase
         Assert.Contains("Plugin dependencies working in AfterBakeAsync", afterContent);
         
         // Should show plugin logs
-        Assert.Contains("TestPluginWithDependencies: BeforeBakeAsync called", result.OutputText);
-        Assert.Contains("TestPluginWithDependencies: AfterBakeAsync called", result.OutputText);
+        Assert.Contains(result.OutputText, o => o.Contains("TestPluginWithDependencies: BeforeBakeAsync called"));
+        Assert.Contains(result.OutputText, o => o.Contains("TestPluginWithDependencies: AfterBakeAsync called"));
     }
 
     private static string GetCurrentDirectory()

--- a/tests/Blake.IntegrationTests/TestPluginWithDependencies/TestPluginWithDependencies.cs
+++ b/tests/Blake.IntegrationTests/TestPluginWithDependencies/TestPluginWithDependencies.cs
@@ -45,6 +45,7 @@ public class TestPluginWithDependencies : IBlakePlugin
         var testMessage = $"Plugin dependencies working in AfterBakeAsync. Created {image.Width}x{image.Height} image. GeneratedPageCount: {context.GeneratedPages.Count}";
         
         var testFilePath = Path.Combine(context.ProjectPath, ".plugin-with-deps-after-bake.txt");
+        logger?.LogInformation("TestPluginWithDependencies: {TestMessage}", testMessage);
         File.WriteAllText(testFilePath, testMessage);
         
         return Task.CompletedTask;


### PR DESCRIPTION
## Summary

Intent of this PR was to ensure all plugin tests were configured correctly, in order to isolate and resolve the issue with loading dependencies of plugin projects. However fixing the assertions in the tests has verified this is working as expected.

PR now includes all tests passing, and adds a PR-test workflow.

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
