### PR TITLE
Enhance failure logging and resilience in content generation process

### DIFF
--- a/src/Blake.BuildTools/Generator/ContentIndexBuilder.cs
+++ b/src/Blake.BuildTools/Generator/ContentIndexBuilder.cs
@@ -1,10 +1,11 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Blake.BuildTools.Generator;
 
 public static class ContentIndexBuilder
 {
-    public static void WriteIndex(string outputPath, List<PageModel> allPages)
+    public static void WriteIndex(string outputPath, List<PageModel> allPages, bool continueOnError, ILogger logger)
     {
         var sb = new StringBuilder();
 
@@ -17,26 +18,53 @@ public static class ContentIndexBuilder
 
         foreach (var page in allPages)
         {
-            sb.AppendLine("        new PageModel");
-            sb.AppendLine("        {");
-            sb.AppendLine($"            Id = @\"{page.Id}\",");
-            sb.AppendLine($"            Title = @\"{page.Title}\",");
-            sb.AppendLine($"            Slug = @\"{page.Slug}\",");
-            sb.AppendLine($"            Description = @\"{page.Description}\",");
-            if (page.Date.HasValue)
-                sb.AppendLine($"            Date = new DateTime({page.Date.Value.Year}, {page.Date.Value.Month}, {page.Date.Value.Day}),");
-            sb.AppendLine($"            Draft = {page.Draft.ToString().ToLowerInvariant()},");
-            sb.AppendLine($"            IconIdentifier = @\"{page.IconIdentifier}\",");
-            sb.AppendLine($"            Tags = new List<string> {{ {string.Join(", ", page.Tags.Select(t => $"\"{t}\""))} }},");
-            sb.AppendLine($"            Image = @\"{page.Image}\",");
-            sb.AppendLine("            Metadata = new Dictionary<string, string>");
-            sb.AppendLine("            {");
-            foreach (var kvp in page.Metadata)
+            var tags = page.Tags ?? [];
+            
+            try
             {
-                sb.AppendLine($"                [\"{kvp.Key}\"] = \"{kvp.Value}\",");
+                sb.AppendLine("        new PageModel");
+                sb.AppendLine("        {");
+                sb.AppendLine($"            Id = @\"{page.Id}\",");
+                sb.AppendLine($"            Title = @\"{page.Title}\",");
+                sb.AppendLine($"            Slug = @\"{page.Slug}\",");
+                sb.AppendLine($"            Description = @\"{page.Description}\",");
+                if (page.Date.HasValue)
+                    sb.AppendLine(
+                        $"            Date = new DateTime({page.Date.Value.Year}, {page.Date.Value.Month}, {page.Date.Value.Day}),");
+                sb.AppendLine($"            Draft = {page.Draft.ToString().ToLowerInvariant()},");
+                sb.AppendLine($"            IconIdentifier = @\"{page.IconIdentifier}\",");
+                if (tags.Count > 0)
+                {
+                    sb.AppendLine(
+                        $"            Tags = new List<string> {{ {string.Join(", ", tags.Select(t => $"\"{t}\""))} }},");
+                }
+                else
+                {
+                    sb.AppendLine($"            Tags = new List<string> {{ }},");
+                }
+                sb.AppendLine($"            Image = @\"{page.Image}\",");
+                sb.AppendLine("            Metadata = new Dictionary<string, string>");
+                sb.AppendLine("            {");
+                foreach (var kvp in page.Metadata)
+                {
+                    sb.AppendLine($"                [\"{kvp.Key}\"] = \"{kvp.Value}\",");
+                }
+
+                sb.AppendLine("            }");
+                sb.AppendLine("        },");
             }
-            sb.AppendLine("            }");
-            sb.AppendLine("        },");
+            catch (Exception e)
+            {
+                if (continueOnError)
+                {
+                    logger.LogWarning(e, "Failed to write page to index. Continuing with next page. Details: ID: {pageId}, Title: {pageTitle}", page.Id, page.Title);
+                }
+                else
+                {
+                    logger.LogError(e, "Failed to write page to index. Details: ID: {pageId}, Title: {pageTitle}", page.Id, page.Title);
+                    throw;
+                }
+            }
         }
 
         sb.AppendLine("    };\n}");

--- a/src/Blake.BuildTools/Generator/SiteGenerator.cs
+++ b/src/Blake.BuildTools/Generator/SiteGenerator.cs
@@ -15,6 +15,8 @@ internal static class SiteGenerator
             ProjectPath = Directory.GetCurrentDirectory(),
             OutputPath = Path.Combine(Directory.GetCurrentDirectory(), ".generated"),
         };
+        
+        var continueOnError = options.Arguments.Contains("--continueOnError") || options.Arguments.Contains("-ce");
 
         logger.LogInformation("🔧 Building site from project path: {OptionsProjectPath}", options.ProjectPath);
         logger.LogInformation("📂 Output path: {OptionsOutputPath}", options.OutputPath);
@@ -68,7 +70,7 @@ internal static class SiteGenerator
             logger.LogDebug("No plugins loaded.");
         }
 
-        await BakeContent(context, options, logger, cancellationToken);
+        await BakeContent(context, options, continueOnError, logger, cancellationToken);
 
         // Run AfterBakeAsync for each plugin
         if (plugins.Count > 0)
@@ -92,7 +94,7 @@ internal static class SiteGenerator
         {
             try
             {
-                await File.WriteAllTextAsync(generatedPage.OutputPath, generatedPage.RazorHtml);
+                await File.WriteAllTextAsync(generatedPage.OutputPath, generatedPage.RazorHtml, cancellationToken);
                 logger.LogDebug("✅ Successfully wrote page: {GeneratedPageOutputPath}", generatedPage.OutputPath);
             }
             catch (Exception ex)
@@ -102,7 +104,7 @@ internal static class SiteGenerator
         }
 
         // Write content index
-        ContentIndexBuilder.WriteIndex(options.OutputPath, [.. context.GeneratedPages.Select(gp => gp.Page)]);
+        ContentIndexBuilder.WriteIndex(options.OutputPath, [.. context.GeneratedPages.Select(gp => gp.Page)], continueOnError, logger);
         logger.LogDebug("✅ Generated content index in {OptionsOutputPath}", options.OutputPath);
     }
 
@@ -281,7 +283,12 @@ internal static class SiteGenerator
         return context;
     }
 
-    private static async Task BakeContent(BlakeContext context, GenerationOptions options, ILogger logger, CancellationToken cancellationToken)
+    private static async Task BakeContent(
+        BlakeContext context,
+        GenerationOptions options,
+        bool continueOnError,
+        ILogger logger,
+        CancellationToken cancellationToken)
     {
         // Bake: Process each markdown file and generate Razor pages
         var mdPipeline = context.PipelineBuilder.Build();
@@ -292,49 +299,69 @@ internal static class SiteGenerator
 
         foreach (var mdPage in context.MarkdownPages)
         {
-            sw.GetStringBuilder().Clear();
-            var mdContent = mdPage.RawMarkdown;
-
-            var frontmatter = FrontmatterHelper.ParseFrontmatter(mdContent, cleanedContent: out _);
-            var page = FrontmatterHelper.MapToMetadata<PageModel>(frontmatter);
-
-            var fileName = Path.GetFileNameWithoutExtension(mdPage.MdPath) ?? "index";
-            var folder = Path.GetDirectoryName(mdPage.MdPath)?.Replace(options.ProjectPath, string.Empty).Trim(Path.DirectorySeparatorChar) ?? string.Empty;
-
-            if (page.Draft && !options.IncludeDrafts)
+            try
             {
-                logger.LogInformation("⚠️  Skipping draft page: {FileName} in {Folder}", fileName, folder);
-                continue;
+                sw.GetStringBuilder().Clear();
+                var mdContent = mdPage.RawMarkdown;
+
+                var frontmatter = FrontmatterHelper.ParseFrontmatter(mdContent, cleanedContent: out _);
+                var page = FrontmatterHelper.MapToMetadata<PageModel>(frontmatter);
+
+                var fileName = Path.GetFileNameWithoutExtension(mdPage.MdPath) ?? "index";
+                var folder =
+                    Path.GetDirectoryName(mdPage.MdPath)?.Replace(options.ProjectPath, string.Empty)
+                        .Trim(Path.DirectorySeparatorChar) ?? string.Empty;
+
+                if (page.Draft && !options.IncludeDrafts)
+                {
+                    logger.LogInformation("⚠️  Skipping draft page: {FileName} in {Folder}", fileName, folder);
+                    continue;
+                }
+
+                page.Slug = mdPage.Slug;
+
+                //var parsedContent = Markdown.ToHtml(mdContent, mdPipeline);
+                // 🔄 Parse the markdown
+                var document = Markdig.Parsers.MarkdownParser.Parse(mdContent, mdPipeline);
+
+                // 🖋️ Render it
+                renderer.Render(document);
+                await renderer.Writer.FlushAsync(cancellationToken);
+
+                // 🔙 Get the rendered HTML
+                var renderedHtml = sw.ToString();
+
+                var generatedRazor =
+                    RazorPageBuilder.BuildRazorPage(mdPage.TemplatePath, renderedHtml, mdPage.Slug, page);
+
+                var outputDir = Path.Combine(options.OutputPath, folder.ToLowerInvariant());
+                Directory.CreateDirectory(outputDir);
+
+                // create output filename - remove spaces or dashes, and convert to PascalCase instead
+                // Razor filenames must be PascalCase and cannot contain spaces or dashes; this avoids enforcing this convention in markdown files
+                var fileNameParts = fileName.Split([' ', '-'], StringSplitOptions.RemoveEmptyEntries);
+                var outputFileName = string.Join("",
+                    fileNameParts.Select(part =>
+                        char.ToUpperInvariant(part[0]) + part.Substring(1).ToLowerInvariant()));
+
+                var outputPath = Path.Combine(outputDir, $"{outputFileName}.razor");
+
+                logger.LogInformation("✅ Generated page: {OutputPath}", outputPath);
+
+                context.GeneratedPages.Add(new GeneratedPage(page, outputPath, generatedRazor));
             }
-
-            page.Slug = mdPage.Slug;
-
-            //var parsedContent = Markdown.ToHtml(mdContent, mdPipeline);
-            // 🔄 Parse the markdown
-            var document = Markdig.Parsers.MarkdownParser.Parse(mdContent, mdPipeline);
-
-            // 🖋️ Render it
-            renderer.Render(document);
-            renderer.Writer.Flush();
-
-            // 🔙 Get the rendered HTML
-            var renderedHtml = sw.ToString();
-
-            var generatedRazor = RazorPageBuilder.BuildRazorPage(mdPage.TemplatePath, renderedHtml, mdPage.Slug, page);
-
-            var outputDir = Path.Combine(options.OutputPath, folder.ToLowerInvariant());
-            Directory.CreateDirectory(outputDir);
-
-            // create output filename - remove spaces or dashes, and convert to PascalCase instead
-            // Razor filenames must be PascalCase and cannot contain spaces or dashes; this avoids enforcing this convention in markdown files
-            var fileNameParts = fileName.Split([' ', '-'], StringSplitOptions.RemoveEmptyEntries);
-            var outputFileName = string.Join("", fileNameParts.Select(part => char.ToUpperInvariant(part[0]) + part.Substring(1).ToLowerInvariant()));
-
-            var outputPath = Path.Combine(outputDir, $"{outputFileName}.razor");
-
-            logger.LogInformation("✅ Generated page: {OutputPath}", outputPath);
-
-            context.GeneratedPages.Add(new GeneratedPage(page, outputPath, generatedRazor));
+            catch (Exception e)
+            {
+                logger.LogError(e, "❌ Error processing markdown file: {MdPath}", mdPage.MdPath);
+                if (continueOnError)
+                {
+                    logger.LogWarning("⚠️  Continuing to process other markdown files despite the error.");
+                }
+                else
+                {
+                    throw; // rethrow if not continuing on error
+                }
+            }
         }
     }
 

--- a/src/Blake.CLI/Program.cs
+++ b/src/Blake.CLI/Program.cs
@@ -90,6 +90,7 @@ public class Program
         Console.WriteLine("                         --disableDefaultRenderers, -dr   Disable the built-in Bootstrap container renderers");
         Console.WriteLine("                         --includeDrafts                  Bakes markdown files that contain 'draft: true' in the frontmatter (they are skipped by default)");
         Console.WriteLine("                         --clean, -cl                     Deletes the .generated folder before re-generating site content");
+        Console.WriteLine("                         --continueOnError, -ce           Continues baking even if some pages fail to generate. By default, the process stops on the first error.");
         Console.WriteLine();
         Console.WriteLine("  new <PATH>           Generates a new Blake site");
         Console.WriteLine("                       Options:");


### PR DESCRIPTION
## Summary

<!-- Describe the change -->
Bake was failing with opaque error messages. This PR adds better logging, as well as a continue-on-error option for the CLI. 

Additionally resolved an issue where content index generation would fail if any pages were missing tags.

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
