### PR TITLE
Add raw HTML to context for access by plugins

### DIFF
--- a/src/Blake.BuildTools/BlakeContext.cs
+++ b/src/Blake.BuildTools/BlakeContext.cs
@@ -45,4 +45,4 @@ public class BlakeContext
 }
 
 public record MarkdownPage(string MdPath, string TemplatePath, string Slug, string RawMarkdown);
-public record GeneratedPage(PageModel Page, string OutputPath, string RazorHtml);
+public record GeneratedPage(PageModel Page, string OutputPath, string RazorHtml, string RawHtml);

--- a/src/Blake.BuildTools/Generator/SiteGenerator.cs
+++ b/src/Blake.BuildTools/Generator/SiteGenerator.cs
@@ -337,7 +337,7 @@ internal static class SiteGenerator
 
                 logger.LogInformation("✅ Generated page: {OutputPath}", outputPath);
 
-                context.GeneratedPages.Add(new GeneratedPage(page, outputPath, generatedRazor));
+                context.GeneratedPages.Add(new GeneratedPage(page, outputPath, generatedRazor, renderedHtml));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary

<!-- Describe the change -->
Currently only the generated Razor output is added to the Blake context. This change includes just the raw parsed HTML output by Markdig. This is important for access in some post-processing scenarios.

Specific use case is to make it available to the RSS plugin, which is an essential use case for a SPA as a static site.

---

🧷 This PR will be released as a **preview** by default.

To trigger a **stable release**:

- Remove the `preview` label
- Add the `release` label
- Optionally add `Semver-Minor` or `Semver-Major` to control version bump

🏷️ Add labels to control release notes:

- `enhancement`, `bug`, `breaking-change`, `dependencies`
- Or use `ignore-for-release` to suppress it from notes
